### PR TITLE
feat: 시나리오 생성 모달 글자수 제한 구현

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,6 +3,13 @@
 @tailwind utilities;
 
 @font-face {
-  font-family: "Minecraft";
+  font-family: 'Minecraft';
   src: url(./../public/asset/font/Minecraft.ttf);
+}
+*::-webkit-scrollbar {
+  display: none;
+}
+* {
+  -ms-overflow-style: none; /* IE and 엣지 */
+  scrollbar-width: none; /* 파이어폭스 */
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
-import MainPage from "./pages/MainPage";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import LandingPage from "./component/LandingPage";
-import ScenarioPage from "./pages/ScenarioPage";
-import ParticleTutorial from "./component/ThreeParticles";
+import MainPage from './pages/MainPage';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import LandingPage from './component/LandingPage';
+import ScenarioPage from './pages/ScenarioPage';
+import ParticleTutorial from './component/ThreeParticles';
 
 const App = () => {
   return (

--- a/src/components/ScenarioModal.tsx
+++ b/src/components/ScenarioModal.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useEffect, useState } from "react";
-import axios from "axios";
-import Carousel from "../components/ImgCarousel";
+import React, { useRef, useEffect, useState, ChangeEvent } from 'react';
+import axios from 'axios';
+import Carousel from '../components/ImgCarousel';
 
 interface ScenarioModalProps {
   isOpen: boolean;
@@ -12,9 +12,9 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
   closeModal,
 }) => {
   const imageUrls = [
-    "/asset/test.png",
-    "/asset/test2.jpeg",
-    "/asset/test3.jpeg",
+    '/asset/test.png',
+    '/asset/test2.jpeg',
+    '/asset/test3.jpeg',
   ];
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -26,8 +26,18 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
     }
   };
   const [user_id, setUserIdValue] = useState(9);
-  const [content, setContentValue] = useState("");
+  const [content, setContentValue] = useState('');
   const [parent_story, setParentValue] = useState(-1);
+  const [characterCount, setCharacterCount] = useState<number>(0);
+  const handleContentChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = e.target.value;
+
+    // 입력을 100글자로 제한
+    if (inputValue.length <= 100) {
+      setContentValue(inputValue);
+      setCharacterCount(inputValue.length);
+    }
+  };
   const CreateScenario = async () => {
     type ErrorType = {
       response: {
@@ -38,8 +48,8 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
     try {
       if (!content.trim()) {
         // content가 공백인 경우 400에러 방지
-        console.log("문장을 입력하세요!");
-        alert("문장을 입력하세요!");
+        console.log('문장을 입력하세요!');
+        alert('문장을 입력하세요!');
         return;
       }
       const response = await axios.post(`/api/v1/stories/`, {
@@ -49,7 +59,7 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
       });
 
       if (response.status === 201) {
-        console.log("성공!");
+        console.log('성공!');
         // 응답이 성공적인 경우 상태 업데이트
         setContentValue(content);
         setUserIdValue(user_id);
@@ -65,21 +75,22 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
   useEffect(() => {
     if (isOpen) {
       // 모달이 열릴 때 외부 클릭 이벤트 리스너 등록
-      document.addEventListener("mousedown", handleBackgroundClick);
+      document.addEventListener('mousedown', handleBackgroundClick);
     } else {
       // 모달이 닫힐 때 외부 클릭 이벤트 리스너 제거
-      document.removeEventListener("mousedown", handleBackgroundClick);
+      document.removeEventListener('mousedown', handleBackgroundClick);
     }
 
     // 컴포넌트 언마운트 시에 이벤트 리스너 정리
     return () => {
-      document.removeEventListener("mousedown", handleBackgroundClick);
+      document.removeEventListener('mousedown', handleBackgroundClick);
     };
   }, [isOpen]);
+
   return (
     <div
       className={`fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 ${
-        isOpen ? "" : "hidden"
+        isOpen ? '' : 'hidden'
       }`}
     >
       <div
@@ -102,10 +113,15 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
               <textarea
                 // type="text"
                 placeholder="문장을 입력하세요."
-                className="h-[140px] p-[5px] mb-[20px] border-dashed border-2 border-white bg-transparent text-white"
+                className="h-[150px] p-[10px]  border-dashed border-2 border-white bg-transparent text-white"
                 value={content}
-                onChange={(e) => setContentValue(e.target.value)}
+                onChange={handleContentChange}
+                maxLength={100}
+                style={{ resize: 'none' }}
               ></textarea>
+              <div className=" flex flex-col items-end  text-white top-10 ">
+                {characterCount}/{100}
+              </div>
               <button
                 className="text-center w-full h-[30px] bg-green-400 border-2 border-gray-500 text-black hover:bg-blue-600 hover:text-white hover:shadow-blue-600"
                 onClick={CreateScenario}

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,13 @@
 @tailwind utilities;
 
 @font-face {
-  font-family: "Minecraft";
+  font-family: 'Minecraft';
   src: url(./../public/asset/font/Minecraft.ttf);
+}
+*::-webkit-scrollbar {
+  display: none;
+}
+* {
+  -ms-overflow-style: none; /* IE and 엣지 */
+  scrollbar-width: none; /* 파이어폭스 */
 }


### PR DESCRIPTION
## Summary
*한 줄 설명*
시나리오 생성 모달 글자수 제한 구현

## Description
- *어떤 코드가 추가/변경 됐는지* 
- ScenarioModal.tsx
- App.css
- index.css 



## Screenshots
*실행 결과 스크린샷*

<img width="1274" alt="image" src="https://github.com/2023-Winter-Bootcamp-Team-J/frontend/assets/154853138/d50149b1-c3db-41bf-8c6e-3691773b510a">

## Test Checklist
- [ ] *테스트할 사람이 어떤 것을 확인하면 좋을지*
- [ ScenarioModal.tsx 뿐만 아니라 App.css 와 index.css에도 변동 사항이 있음] 
