### PR TITLE
feat: 시나리오 페이지 스토리 1개 상세 조회 및 뒤로 가기 구현

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,7 +10,7 @@ const Navbar = () => {
 
   // user가 변경되면 실행
   useEffect(() => {
-    console.log("user: ", user);
+    // console.log("user: ", user);
   }, [user]);
   const handleNavigate = () => {
     // '/landingpage'로 페이지 이동

--- a/src/components/ScenarioModal.tsx
+++ b/src/components/ScenarioModal.tsx
@@ -1,8 +1,8 @@
-import React, { useRef, useEffect, useState, ChangeEvent } from 'react';
-import axios from 'axios';
-import Carousel from '../components/ImgCarousel';
-import Lottie from 'lottie-react';
-import lottieData from '../assets/lottie.json';
+import React, { useRef, useEffect, useState, ChangeEvent } from "react";
+import axios from "axios";
+import Carousel from "../components/ImgCarousel";
+import Lottie from "lottie-react";
+import lottieData from "../assets/lottie.json";
 import { useRecoilValue } from "recoil";
 import { userState } from "../recoil/atoms";
 
@@ -23,9 +23,9 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
     }
   };
   const modalRef = useRef<HTMLDivElement>(null);
-  const [content, setContentValue] = useState('');
-  const [taskID, setTaskID] = useState('');
-  const [imageUrl, setImageUrl] = useState<string>('');
+  const [content, setContentValue] = useState("");
+  const [taskID, setTaskID] = useState("");
+  const [imageUrl, setImageUrl] = useState<string>("");
   const [images, setImages] = useState<string[]>([]);
   const [characterCount, setCharacterCount] = useState<number>(0);
   const [isGenerating, setIsGenerating] = useState(false); // Lottie를 트리거
@@ -59,8 +59,8 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
     try {
       if (!content.trim()) {
         // content가 공백인 경우 400에러 방지
-        console.log('문장을 입력하세요!');
-        alert('문장을 입력하세요!');
+        console.log("문장을 입력하세요!");
+        alert("문장을 입력하세요!");
         return;
       }
       const response = await axios.post(`/api/v1/stories/images`, {
@@ -91,7 +91,7 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
     const ShowImage = async () => {
       try {
         if (!taskID) {
-          console.log('taskID가 없습니다.');
+          console.log("taskID가 없습니다.");
           return;
         }
         const response = await axios.get(`/api/v1/stories/images`, {
@@ -99,7 +99,7 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
             task_id: taskID,
           },
         });
-        
+
         if (response.status === 200) {
           console.log("이미지 생성 성공!");
           const newImageUrl = response.data.image_url.image_url;
@@ -156,21 +156,21 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
   useEffect(() => {
     if (isOpen) {
       // 모달이 열릴 때 외부 클릭 이벤트 리스너 등록
-      document.addEventListener('mousedown', handleBackgroundClick);
+      document.addEventListener("mousedown", handleBackgroundClick);
     } else {
       // 모달이 닫힐 때 외부 클릭 이벤트 리스너 제거
-      document.removeEventListener('mousedown', handleBackgroundClick);
+      document.removeEventListener("mousedown", handleBackgroundClick);
     }
     // 컴포넌트 언마운트 시에 이벤트 리스너 정리
     return () => {
-      document.removeEventListener('mousedown', handleBackgroundClick);
+      document.removeEventListener("mousedown", handleBackgroundClick);
     };
   }, [isOpen]);
 
   return (
     <div
       className={`fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 ${
-        isOpen ? '' : 'hidden'
+        isOpen ? "" : "hidden"
       }`}
     >
       <div
@@ -204,7 +204,7 @@ const ScenarioModal: React.FC<ScenarioModalProps> = ({
                 // onChange={(e) => setContentValue(e.target.value)}
                 onChange={handleContentChange}
                 maxLength={100}
-                style={{ resize: 'none' }}
+                style={{ resize: "none" }}
               ></textarea>
               <div className=" flex flex-col items-end  text-white top-10 ">
                 {characterCount}/{100}

--- a/src/components/StoryModal.tsx
+++ b/src/components/StoryModal.tsx
@@ -1,40 +1,160 @@
-import React from "react";
+import axios from "axios";
+import React, { useEffect, useRef, useState } from "react";
 
-const StoryModal = () => {
+interface StoryModalProps {
+  story_id: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const StoryModal: React.FC<StoryModalProps> = ({
+  story_id,
+  isOpen,
+  onClose,
+}) => {
+  const [storyId, setStoryId] = useState(story_id);
+  const [story, setStory] = useState<{
+    user_nickname: string;
+    content: string;
+    image_url: string;
+    child_id: number[];
+    child_content: string[];
+  } | null>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  // console.log("story_id: ", story_id);
+
+  const handleClickChildren = (childId: number) => {
+    console.log("child: ", childId);
+    if (childId) {
+      setStoryId(childId);
+    }
+  };
+
+  // 모달 외부를 클릭했을 때 모달을 닫도록 하는 이벤트 처리
+  const handleClickOutside = (e: MouseEvent) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      // 모달이 열릴 때 외부 클릭 이벤트 리스너 등록
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      // 모달이 닫힐 때 외부 클릭 이벤트 리스너 제거
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+    // 컴포넌트 언마운트 시에 이벤트 리스너 정리
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    console.log("**story_id: ", storyId);
+    const storyAPI = async () => {
+      try {
+        const response = await axios.get(`api/v1/stories/${storyId}`);
+        console.log("response: ", response.data.data);
+        if (response.data.data) {
+          // 데이터가 존재할 때만 state 업데이트
+          setStory({
+            user_nickname: response.data.data.user_nickname,
+            content: response.data.data.content,
+            image_url: response.data.data.image_url,
+            child_id: response.data.data.child_id,
+            child_content: response.data.data.child_content,
+          });
+        }
+      } catch (error) {
+        console.error("Error fetching story data:", error);
+      }
+    };
+
+    storyAPI();
+  }, [storyId]);
+
+  useEffect(() => {
+    console.log("story: ", story);
+  }, [story]);
+
   return (
-    <div className="flex flex-col w-[800px] h-[450px]">
-      <div className="flex gap-[15px] w-full h-[55px] justify-center items-center bg-blue-800 border-2 border-gray-400 text-green-400 text-[33px] font-Minecraft">
-        STORY
-        <div className="text-gray-400 text-[18px]">by 앤드류</div>
-      </div>
-      <div className="flex flex-col w-full h-[395px] justify-center items-center gap-[10px] bg-stone-50 border-2 border-gray-400 ">
-        <div className="flex justify-center w-full h-[270px] gap-[80px]">
-          <div className="w-[270px] bg-gray-500">이미지</div>
-          <div className="flex flex-col justify-center w-[300px] gap-[10px] text-center">
-            <div className="flex items-center w-[300px] gap-[20px]">
-              <div className="w-[300px] h-[120px] p-[5px] mb-[20px] border-dashed border-2 border-gray-500 bg-transparent ">
-                알렉스는 지역에서 유명한 폐허가 된 저택을 탐험하기로 결심한다.
-                이 저택은 오랫동안 불길한 소문이 돌아왔으며, 많은 사람들이
-                그곳에 가는 것을 꺼려합니다.
-              </div>
+    <div
+      className={`fixed top-0 left-0 w-[100vw] h-[100vh] bg-black bg-opacity-50 ${
+        isOpen ? "" : "hidden"
+      }`}
+    >
+      <div ref={modalRef} className="flex flex-col w-[800px] h-[450px] z-10">
+        <div className="flex gap-[15px] w-full h-[55px] justify-center items-center bg-blue-800 border-2 border-gray-400 text-green-400 text-[33px] font-Minecraft">
+          STORY
+          <div className="text-gray-400 text-[18px]">
+            by {story?.user_nickname ? `${story.user_nickname}` : "LOADING..."}
+          </div>
+        </div>
+        <div className="flex flex-col w-full h-[395px] justify-center items-center gap-[10px] bg-black text-white border-2 border-gray-400 ">
+          <div className="flex justify-center w-full h-[270px] gap-[80px]">
+            <div className="w-[270px] bg-gray-500">
+              <img
+                className="w-full block"
+                src={story?.image_url ? `${story.image_url}` : ""}
+                alt="슬라이드4"
+              />
             </div>
-            <div className="flex items-center w-[300px] gap-[20px] hover:scale-105 hover:border-2 border-dashed hover:border-blue-600">
-              <img className="flex w-[40px]" src="/asset/hand.svg" alt="손" />
-              <div className="w-[300px] h-[50px] p-[5px]">
-                포상금이 10억인걸 알았다. ...
+            <div className="flex flex-col justify-center w-[300px] gap-[10px]">
+              <div className="flex items-center w-[300px] gap-[20px]">
+                <div className="w-[300px] h-[120px] p-[5px] mb-[20px] border-dashed border-2 border-gray-500 bg-transparent ">
+                  {story?.content ? `${story.content}` : "LOADING..."}
+                </div>
               </div>
-            </div>
-            <div className="flex items-center w-[300px] gap-[20px] hover:scale-105">
-              <img className="flex w-[40px]" src="/asset/hand.svg" alt="손" />
-              <div className="w-[300px] h-[50px] p-[5px] border-dashed  hover:border-2 hover:border-blue-600 bg-transparent ">
-                포상금이 5천만원 밖에 안...
+              <div className="flex items-center w-[300px] gap-[20px] hover:scale-105 hover:border-2 border-dashed hover:border-blue-600">
+                <img className="flex w-[40px]" src="/asset/hand.svg" alt="손" />
+                <div
+                  onClick={() => {
+                    handleClickChildren(
+                      story?.child_id && story.child_id[0]
+                        ? story.child_id[0]
+                        : 0
+                    );
+                  }}
+                  className="w-[300px] h-[50px] p-[5px]"
+                >
+                  {story?.child_content && story.child_content[0] ? (
+                    `${story.child_content[0]}`
+                  ) : (
+                    <span className="text-blue-600">
+                      새로운 이야기를 만들어보세요!
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center w-[300px] gap-[20px] hover:scale-105">
+                <img className="flex w-[40px]" src="/asset/hand.svg" alt="손" />
+                <div
+                  onClick={() => {
+                    handleClickChildren(
+                      story?.child_id && story.child_id[1]
+                        ? story.child_id[1]
+                        : 0
+                    );
+                  }}
+                  className="w-[300px] h-[50px] p-[5px] border-dashed  hover:border-2 hover:border-blue-600 bg-transparent "
+                >
+                  {story?.child_content && story.child_content[1] ? (
+                    `${story.child_content[1]}`
+                  ) : (
+                    <span className="text-blue-600">
+                      새로운 이야기를 만들어보세요!
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
           </div>
+          <button className="flex w-[50px] justify-center mt-[10px] bg-zinc-300 border-2 border-gray-500 font-Minecraft font-bold text-black text-[20px] hover:bg-blue-600 hover:text-green-400 hover:shadow-blue-600">
+            OK
+          </button>
         </div>
-        <button className="flex w-[50px] justify-center mt-[10px] bg-zinc-300 border-2 border-gray-500 font-Minecraft font-bold text-black text-[20px] hover:bg-blue-600 hover:text-green-400 hover:shadow-blue-600">
-          OK
-        </button>
       </div>
     </div>
   );

--- a/src/components/ThreeParticles.tsx
+++ b/src/components/ThreeParticles.tsx
@@ -1,18 +1,15 @@
-import React, { useEffect, useRef } from 'react';
-import * as THREE from 'Three';
-
+import React, { useEffect, useRef } from "react";
+import * as THREE from "Three";
 const ParticleTutorial: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const particles: THREE.Points[] = [];
-
   useEffect(() => {
     let camera: THREE.PerspectiveCamera;
     let scene: THREE.Scene;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let mouseX = 0;
     let mouseY = 0;
-
     const init = () => {
       camera = new THREE.PerspectiveCamera(
         100,
@@ -21,41 +18,32 @@ const ParticleTutorial: React.FC = () => {
         4000
       );
       camera.position.z = 2000;
-
       scene = new THREE.Scene();
       scene.background = new THREE.Color(0x000720);
       scene.add(camera);
-
       const renderer = new THREE.WebGLRenderer();
       renderer.setSize(window.innerWidth, window.innerHeight);
       rendererRef.current = renderer;
-
       if (containerRef.current) {
         containerRef.current.appendChild(renderer.domElement);
       }
-
       makeParticles();
-
-      document.addEventListener('mousemove', onMouseMove, false);
-      window.addEventListener('resize', onWindowResize);
-      setInterval(update, 1000 / 50);
+      document.addEventListener("mousemove", onMouseMove, false);
+      window.addEventListener("resize", onWindowResize);
+      setInterval(update, 1000 / 80);
     };
-
     const update = () => {
       updateParticles();
       if (rendererRef.current) {
         rendererRef.current.render(scene, camera);
       }
     };
-
     const makeParticles = () => {
       const colors = [0x98adf9, 0x7aff8f, 0xffffff];
       const distance = 2200;
-
       for (let zpos = -distance; zpos < distance; zpos += 15) {
         const colorIndex = Math.floor(Math.random() * colors.length);
         const color = colors[colorIndex];
-
         const geometry = new THREE.BufferGeometry();
         const vertices = [
           Math.random() * (distance * 2) - distance,
@@ -63,32 +51,29 @@ const ParticleTutorial: React.FC = () => {
           zpos,
         ];
         geometry.setAttribute(
-          'position',
+          "position",
           new THREE.Float32BufferAttribute(vertices, 3)
         );
-
         const material = new THREE.PointsMaterial({ color: color, size: 10 });
-
         const particle = new THREE.Points(geometry, material);
-
         scene.add(particle);
         particles.push(particle);
       }
     };
-
     const updateParticles = () => {
       for (let i = 0; i < particles.length; i++) {
         const particle = particles[i];
-        particle.position.z += mouseY * 0.03;
-        if (particle.position.z > 1500) particle.position.z -= 2500;
+        particle.position.z += mouseY * 0.008;
+        if (particle.position.z > 1500) {
+          // 보간을 사용하여 부드럽게 이동
+          particle.position.z = -1000 + (particle.position.z - 1000);
+        }
       }
     };
-
     const onMouseMove = (event: MouseEvent) => {
       mouseX = event.clientX;
       mouseY = event.clientY;
     };
-
     const onWindowResize = () => {
       if (rendererRef.current && camera) {
         camera.aspect = window.innerWidth / window.innerHeight;
@@ -96,9 +81,7 @@ const ParticleTutorial: React.FC = () => {
         rendererRef.current.setSize(window.innerWidth, window.innerHeight);
       }
     };
-
     init();
-
     return () => {
       // Clean up code (e.g., remove event listeners, dispose Three.js resources)
       if (rendererRef.current) {
@@ -108,11 +91,9 @@ const ParticleTutorial: React.FC = () => {
           rendererContainer.removeChild(rendererRef.current.domElement);
         }
       }
-      window.removeEventListener('resize', onWindowResize);
+      window.removeEventListener("resize", onWindowResize);
     };
   }, []); // 빈 dependency array로 설정하여 한 번만 실행되도록
-
   return <div ref={containerRef}>{/* 나머지 JSX */}</div>;
 };
-
 export default ParticleTutorial;

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import ThreeParticles from "../components/ThreeParticles";
 import NicknameModal from "../components/NicknameModal";
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import Navbar from "@/components/Navbar";
 import SwiperComponent from "@/components/Swiper";
 import ScenarioModal from "@/components/ScenarioModal";

--- a/src/pages/ScenarioPage.tsx
+++ b/src/pages/ScenarioPage.tsx
@@ -1,6 +1,7 @@
 import ParticleTutorial from "@/components/ThreeParticles";
 import ForceGraph from "@/components/ForceGraph";
 import Navbar from "@/components/Navbar";
+import { useNavigate } from "react-router-dom";
 // import { useLocation } from "react-router-dom";
 
 const ScenarioPage = () => {
@@ -8,6 +9,11 @@ const ScenarioPage = () => {
   // const state = location.state as { story_id: number };
   // const story_id = state.story_id;
   const story_id = 9;
+  const navigate = useNavigate();
+
+  const handleClickBack = () => {
+    navigate(-1);
+  };
 
   return (
     <div>
@@ -20,6 +26,30 @@ const ScenarioPage = () => {
             <ForceGraph storyId={story_id} />
           </div>
         </div>
+      </div>
+      <div
+        onClick={handleClickBack}
+        className="w-[50px] h-[50px] text-white absolute left-8 bottom-8"
+      >
+        <svg
+          className="hover:scale-125 hover:opacity-35 h-full drop-shadow"
+          style={{
+            filter: "drop-shadow(7px 1px 8px rgba(255, 255, 255, 0.7))",
+          }}
+          data-slot="icon"
+          fill="none"
+          stroke-width="2"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+          ></path>
+        </svg>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
*한 줄 설명*
시나리오 페이지 스토리 1개 상세 조회 및 뒤로 가기 구현

## Description
- *어떤 코드가 추가/변경 됐는지*
- ForceGraph.jsx 클릭 이벤트 및 API 조회
- ScenarioModal.tsx 뒤로가기 아이콘 추가 및 navigate 기능 구현

## Screenshots
*실행 결과 스크린샷*
<img width="958" alt="스크린샷 2024-01-20 오후 5 48 46" src="https://github.com/2023-Winter-Bootcamp-Team-J/frontend/assets/94193594/65014885-964b-4dcf-802b-3a659afdaa16">

## Test Checklist
*테스트할 사람이 어떤 것을 확인하면 좋을지*
- [ ] 조회가 정상적으로 되는지
- [ ] 자식 스토리 클릭 시 조회가 되는지
