### PR TITLE
feat: 메인 페이지 닉네임, 내용 출력 및 시나리오 페이지 URL 설계 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => {
         <Routes>
           <Route path="/main" element={<MainPage />} />
           <Route path="/" element={<LandingPage />} />
-          <Route path="/scenario" element={<ScenarioPage />} />
+          <Route path="/scenario/:rootId" element={<ScenarioPage />} />
           <Route path="/three" element={<ParticleTutorial />} />
         </Routes>
       </Router>

--- a/src/components/RootModal.tsx
+++ b/src/components/RootModal.tsx
@@ -9,7 +9,7 @@ interface RootModalProps {
   storyId: number;
 }
 
-const RootModal: React.FC<StoryModalProps> = ({
+const RootModal: React.FC<RootModalProps> = ({
   isOpen,
   closeStory,
   storyId,
@@ -53,11 +53,13 @@ const RootModal: React.FC<StoryModalProps> = ({
 
   const handleOkButtonClick = () => {
     // OK 버튼 클릭 시 ScenarioPage로 이동
-    navigate("/scenario", {
-      state: {
-        story_id: storyId,
-      },
-    });
+    // navigate("/scenario", {
+    //   state: {
+    //     story_id: storyId,
+    //   },
+    // });
+    const rootId = storyId;
+    navigate(`/scenario/${rootId}`);
   };
 
   const modalRef = useRef<HTMLDivElement>(null);

--- a/src/components/Swiper.tsx
+++ b/src/components/Swiper.tsx
@@ -87,7 +87,7 @@ const SwiperComponent: React.FC<SwiperComponentProps> = ({
         slideChange: (swiper) => {
           // 중앙에 위치한 슬라이드의 인덱스를 업데이트
           setCurrentSlideIndex(swiper.realIndex);
-          console.log(currentSlideIndex);
+          // console.log(currentSlideIndex);
         },
       },
       modules: [EffectCoverflow, Navigation, Mousewheel, Pagination],
@@ -105,6 +105,12 @@ const SwiperComponent: React.FC<SwiperComponentProps> = ({
       swiper.destroy();
     };
   }, [stories]);
+
+  useEffect(() => {
+    console.log("currentSlideIndex: ", currentSlideIndex);
+    console.log("stories: ", stories[currentSlideIndex]);
+    onSlideClick(currentSlideIndex);
+  }, [currentSlideIndex]);
 
   return (
     <div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -52,6 +52,7 @@ const MainPage = () => {
   useEffect(() => {
     RootStory();
   }, [update]);
+
   return (
     <div>
       <ThreeParticles />

--- a/src/pages/ScenarioPage.tsx
+++ b/src/pages/ScenarioPage.tsx
@@ -1,16 +1,21 @@
 import ParticleTutorial from "../components/ThreeParticles";
 import ForceGraph from "../components/ForceGraph";
 import Navbar from "../components/Navbar";
-import { useLocation, useNavigate } from "react-router-dom";
+// import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import StoryModal from "../components/StoryModal";
 import CreateStoryModal from "../components/CreateStoryModal";
 import axios from "axios";
 
 const ScenarioPage = () => {
-  const location = useLocation();
-  const state = location.state as { story_id: number };
-  const story_id = state.story_id; // story_id 전달 받기
+  // const location = useLocation();
+  // const state = location.state as { story_id: number };
+  // const story_id = state.story_id; // story_id 전달 받기
+  const { rootId } = useParams() as { rootId: string };
+  console.log("rootId: ", rootId);
+  const story_id = parseInt(rootId, 10);
+  // console.log("storyId: ", storyId);
   const navigate = useNavigate(); // 뒤로 가기
 
   const [isStoryModalOpen, setIsStoryModalOpen] = useState(false);
@@ -25,7 +30,7 @@ const ScenarioPage = () => {
   };
 
   const openModal = (storyId: number) => {
-    console.log("click_id: ", story_id);
+    console.log("click_id: ", storyId);
     // 클릭한 스토리 아이디로 모달 열기
     setClickStoryId(storyId);
     setIsStoryModalOpen(true);
@@ -37,26 +42,27 @@ const ScenarioPage = () => {
     setIsCreateModalOpen(false);
   };
 
-  const handleClickStory = (story_id: number) => {
+  const handleClickStory = (storyId: number) => {
     // 스토리 생성 or 조회
-    if (story_id < 0) {
+    if (storyId < 0) {
       // 생성
       setIsStoryModalOpen(false);
       setIsCreateModalOpen(true);
     } else {
       // 조회
-      setClickStoryId(story_id);
+      setClickStoryId(storyId);
     }
   };
 
   useEffect(() => {
+    console.log("storyId: ", story_id);
     const scenarioAPI = async () => {
       try {
         const response = await axios.get(
-          `api/v1/stories/branches/${story_id}/`
+          `http://localhost:3001/api/v1/stories/branches/${story_id}/`
         );
-        // console.log("response: ", response.data.data);
-        if (response.data.data.length > 0) {
+        console.log("response: ", response.data.data);
+        if (response.status == 200) {
           setScenario(response.data.data);
         }
       } catch (error) {

--- a/src/pages/ScenarioPage.tsx
+++ b/src/pages/ScenarioPage.tsx
@@ -59,7 +59,7 @@ const ScenarioPage = () => {
     const scenarioAPI = async () => {
       try {
         const response = await axios.get(
-          `http://localhost:3001/api/v1/stories/branches/${story_id}/`
+          `/api/v1/stories/branches/${story_id}/`
         );
         console.log("response: ", response.data.data);
         if (response.status == 200) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     port: 3000,
     host: true,
     proxy: {
-      "/api": "http://localhost:8000",
+      "/api": "http://localhost",
     },
   },
   resolve: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     port: 3000,
     host: true,
     proxy: {
-      "/api": "http://localhost",
+      "/api": "http://localhost:8000",
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
*한 줄 설명*

메인 페이지 닉네임, 내용 출력 및 시나리오 페이지 URL 설계 구현

## Description
- *어떤 코드가 추가/변경 됐는지*
- App.tsx
- RootModal.tsx
- Swiper.tsx
- MainPage.tsx
- ScenarioPage.tsx


## Screenshots
*실행 결과 스크린샷*
- 루트스토리 아이디: 0 의 전체 스토리 조회

<img width="1170" alt="스크린샷 2024-01-24 오전 1 23 33" src="https://github.com/2023-Winter-Bootcamp-Team-J/frontend/assets/94193594/a95dcba9-78ef-4a23-b261-01042dce7f57">

- 루트스토리 아이디: 17

<img width="1175" alt="스크린샷 2024-01-24 오전 1 23 54" src="https://github.com/2023-Winter-Bootcamp-Team-J/frontend/assets/94193594/efed0d3f-a060-4b80-8590-ee1fea5ab4e3">


## Test Checklist
- [ ] *테스트할 사람이 어떤 것을 확인하면 좋을지*
- [ ] 
